### PR TITLE
use different user for credentials and commits

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   release-pr:
-    uses: OliverMKing/javascript-release-workflow/.github/workflows/release-pr.yml@main
+    uses: Sonlis/javascript-release-workflow/.github/workflows/release-pr.yml@main
     with:
       release: ${{ github.event.inputs.release }}

--- a/.github/workflows/tag-and-draft.yaml
+++ b/.github/workflows/tag-and-draft.yaml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   tag-and-release:
-    uses: OliverMKing/javascript-release-workflow/.github/workflows/tag-and-release.yml@main
+    uses: Sonlis/javascript-release-workflow/.github/workflows/tag-and-release.yml@main


### PR DESCRIPTION
Use personal workflow for credentials and commits identification.